### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-jxlib.org


### PR DESCRIPTION
Removing invalid redirect since we no longer own jxlib.org.
